### PR TITLE
Webhook v2: PlutoSlidersServer with self-updating Capabilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.2"
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
+FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 FromFile = "ff7dd447-1dcb-4ce3-b8ac-22a812192de7"
 GitHubActions = "6b79fd1a-b13a-48ab-b6b0-aaee1fee41df"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -68,6 +68,27 @@ module Actions
         notebook_sessions[i], jl_contents, original_state
     end
 
+    function renew_session!(notebook_sessions, server_session, path)
+        @info "Renewing " path
+        new_hash = path_hash(path)
+        i = findfirst(s -> s.path == path, notebook_sessions)
+        if isnothing(i)
+            @warn "Can't find session to renew"
+            return (nothing, nothing, nothing)
+        end
+        session = notebook_sessions[i]
+        ## DID NOTEBOOK GET UPDATED?
+        bond_connections = MoreAnalysis.bound_variable_connections_graph(session.notebook)
+        original_state = Pluto.notebook_to_js(session.notebook)
+        notebook_sessions[i] = RunningNotebookSession(;
+             path,
+             hash=new_hash,
+             notebook=session.notebook,
+             original_state,
+             bond_connections,
+         )
+    end
+
     function remove_from_session!(notebook_sessions, server_session, hash)
         i = findfirst(notebook_sessions) do sesh
             sesh.hash === hash

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -3,14 +3,24 @@ module Actions
     using Base64
     using SHA
     using FromFile
+    export myhash, path_hash, showall, add_to_session!, renew_session!, remove_from_session!, register_webhook, run_folder, get_paths_from, generate_static_export
     @from "./MoreAnalysis.jl" import MoreAnalysis 
     @from "./Export.jl" using Export
     @from "./Types.jl" using Types
     @from "./FileHelpers.jl" import FileHelpers: find_notebook_files_recursive
     myhash = base64encode ∘ sha256
+    path_hash = path -> myhash(read(path))
+
     showall(xs) = Text(join(string.(xs),"\n"))
 
-    function add_to_session!(notebook_sessions, server_session, path, settings, run_server=true, start_dir=".")
+    """
+    Core Action. 
+    
+    add_to_session! lets PlutoSliderServer know about a new session
+    start_dir should come from settings
+    """
+    function add_to_session!(notebook_sessions, server_session, path, settings, run_server, start_dir)
+        # TODO: Take these from Settings
         jl_contents = read(joinpath(start_dir, path), String)
         hash = myhash(jl_contents)
         # The 5 lines below are needed if the code is not invoked within PlutoSliderServer.run_directory
@@ -25,6 +35,7 @@ module Actions
         local notebook, original_state
 
         cached_state = skip_cache ? nothing : try_fromcache(settings.Export.cache_dir, hash)
+        # This probably only works in github action context
         if cached_state !== nothing
             @info "Loaded from cache, skipping notebook run" hash
             original_state = cached_state
@@ -68,8 +79,46 @@ module Actions
         notebook_sessions[i], jl_contents, original_state
     end
 
-    function renew_session!(notebook_sessions, server_session, path)
+    """
+    Wait for notebook to have 0 running or queued cells
+    Poll in intervals of 5 seconds
+    """
+    function waitnotebookready(notebook::Pluto.Notebook)
+        i = 0
+        sleep(3)  # "Make sure" pluto picked up the change in notebook 
+        println("Waiting for notebook to get ready")
+        while (i < 360)
+            isrunning = length(filter(cell -> (cell.queued || cell.running), notebook.cells)) > 0
+            if (!isrunning)
+                println("")
+                return
+            end
+            print("\r\nWaiting for notebook to be ready [$(5*i)s]")
+            sleep(5)
+            i += 1
+        end
+        @error "Couldn't get the notebook status after 30 minutes."
+    end
+
+    """
+    Core Action. Renew a session without restarting it!
+
+    This function renews the RunningNotebookSession that the PlutoSliderServer
+    tracks with
+    1. updated hash (serve correct GET requests)
+    2. updated bond_connections
+    3. update original_state (will be used in export, if that is set)
+    This implementation assumes Pluto will watch file updates
+    There is a race condition there:
+        Webhook
+            -> pull
+            -> file changes
+                -> pluto picksup the change [is the file ready?]
+            -> renew_session [is pluto running? has pluto picked up file change?]
+    """
+    function renew_session!(notebook_sessions, server_session, path, settings)
         @info "Renewing " path
+        jl_contents = read(joinpath(settings.SliderServer.start_dir, path), String)
         new_hash = path_hash(path)
         i = findfirst(s -> s.path == path, notebook_sessions)
         if isnothing(i)
@@ -77,7 +126,7 @@ module Actions
             return (nothing, nothing, nothing)
         end
         session = notebook_sessions[i]
-        ## DID NOTEBOOK GET UPDATED?
+        waitnotebookready(session.notebook)
         bond_connections = MoreAnalysis.bound_variable_connections_graph(session.notebook)
         original_state = Pluto.notebook_to_js(session.notebook)
         notebook_sessions[i] = RunningNotebookSession(;
@@ -87,8 +136,11 @@ module Actions
              original_state,
              bond_connections,
          )
+         notebook_sessions[i], jl_contents, original_state
     end
-
+    """
+    Core Action. Stops a notebook from running in PlutoSliderServer
+    """
     function remove_from_session!(notebook_sessions, server_session, hash)
         i = findfirst(notebook_sessions) do sesh
             sesh.hash === hash
@@ -106,8 +158,12 @@ module Actions
         )
     end
 
+    """
+    Starts and creates static exports for all notebooks in a folder,
+    respecting the settings provided
+    """
     function run_folder(folder, notebook_sessions, server_session, settings, output_dir)
-        to_run = get_paths_from(folder, settings)[1:3]
+        to_run = get_paths_from(folder, settings)
         for path in to_run
             @info path "starting"
             session, jl_contents, original_state = add_to_session!(notebook_sessions, server_session, path, settings, true, folder)
@@ -118,11 +174,24 @@ module Actions
         @info "success"
     end
 
+    """
+    Helper function to get the paths in a folder , excluding those
+    set for exclusion in settings
+    """
     function get_paths_from(folder, settings)
         notebook_paths = find_notebook_files_recursive(folder)
         to_run = setdiff(notebook_paths, settings.SliderServer.exclude)
     end
 
+    """
+    Core Action: Generate static export for a Pluto Notebook
+    Settings must specify
+    1. slider_server_url: URL of the slider server. This will be the URL of your server, if you deploy
+    2. offer_binder: Flag to enable the Binder button
+    3. binder_url: URL of the binder link that will be invoked. Use a compatible pluto-enabled binder 
+    4. baked_state: Whether to export pluto state within the html or in a separate file.
+    5. pluto_cdn_root: URL where pluto will go to find the static frontend assets 
+    """
     function generate_static_export(path, settings, original_state, output_dir, jl_contents)
         pluto_version = Export.try_get_exact_pluto_version()
         export_jl_path = let

--- a/src/Export.jl
+++ b/src/Export.jl
@@ -67,7 +67,7 @@ function try_get_exact_pluto_version()
             p.git_revision
         end
     catch e
-        @error "Failed to get exact Pluto version from dependency. Your website is not guaranteed to work forever." exception=(e, catch_backtrace())
+        @error "Failed to get exact Pluto version from dependency. Your website is not guaranteed to work forever." # exception=(e, catch_backtrace())
         Pluto.PLUTO_VERSION
     end
 end

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -15,8 +15,6 @@ using HTTP
 using Base64
 using SHA
 using Sockets
-using Configurations
-using TOML
 
 using Logging: global_logger
 using GitHubActions: GitHubActionsLogger
@@ -24,23 +22,7 @@ function __init__()
     get(ENV, "GITHUB_ACTIONS", "false") == "true" && global_logger(GitHubActionsLogger())
 end
 
-function get_configuration(toml_path::Union{Nothing,String}=nothing; kwargs...)
-    if !isnothing(toml_path) && isfile(toml_path)
-        toml_d = TOML.parsefile(toml_path)
-        
-        kwargs_dict = Configurations.to_dict(Configurations.from_kwargs(PlutoDeploySettings; kwargs...))
-        Configurations.from_dict(PlutoDeploySettings, merge_recursive(toml_d, kwargs_dict))
-    else
-        Configurations.from_kwargs(PlutoDeploySettings; kwargs...)
-    end
-end
-
-merge_recursive(a::AbstractDict, b::AbstractDict) = mergewith(merge_recursive, a, b)
-merge_recursive(a, b) = b
-
 include("./HTTPRouter.jl")
-
-
 
 export export_directory, run_directory, github_action, run
 

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -24,7 +24,7 @@ end
 
 include("./HTTPRouter.jl")
 
-export export_directory, run_directory, github_action, run
+export export_directory, run_directory, github_action, runrepository, run_server
 
 
 """

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -37,6 +37,8 @@ module Types
         host="127.0.0.1"
         simulated_lag::Real=0
         serve_static_export_folder::Bool=true
+        start_dir="." # Relative to julia that is running
+        repository::Union{Nothing,String}=nothing
     end
     
     @option struct ExportSettings

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1,7 +1,8 @@
 module Types
     using Configurations
+    using TOML
     import Pluto: Pluto, Token, Notebook
-    export NotebookSession, RunningNotebookSession, QueuedNotebookSession, FinishedNotebookSession, SliderServerSettings, ExportSettings, PlutoDeploySettings
+    export NotebookSession, RunningNotebookSession, QueuedNotebookSession, FinishedNotebookSession, SliderServerSettings, ExportSettings, PlutoDeploySettings, get_configuration
     ###
     # SESSION DEFINITION
     
@@ -60,5 +61,18 @@ module Types
         Export::ExportSettings=ExportSettings()
         Pluto::Pluto.Configuration.Options=Pluto.Configuration.Options()
     end
-
+    
+    function get_configuration(toml_path::Union{Nothing,String}=nothing; kwargs...)
+        if !isnothing(toml_path) && isfile(toml_path)
+            toml_d = TOML.parsefile(toml_path)
+            
+            kwargs_dict = Configurations.to_dict(Configurations.from_kwargs(PlutoDeploySettings; kwargs...))
+            Configurations.from_dict(PlutoDeploySettings, merge_recursive(toml_d, kwargs_dict))
+        else
+            Configurations.from_kwargs(PlutoDeploySettings; kwargs...)
+        end
+    end
+    
+    merge_recursive(a::AbstractDict, b::AbstractDict) = mergewith(merge_recursive, a, b)
+    merge_recursive(a, b) = b
 end

--- a/src/UpdateFromFile.jl
+++ b/src/UpdateFromFile.jl
@@ -1,0 +1,50 @@
+"""
+    Pluto Polyfill: don't use when/if Pluto implements this!
+"""
+module UpdateFromFile
+
+export update_from_file
+
+    import Pluto: update_save_run!, load_notebook_nobackup, ServerSession, Notebook, Cell
+    function update_from_file(session::ServerSession, notebook::Notebook)
+    	just_loaded = try
+    		sleep(0.5) ## There seems to be a synchronization issue if your OS is VERYFAST 
+    		load_notebook_nobackup(notebook.path)
+    	catch e
+    		@error "Skipping hot reload because loading the file went wrong" exception=(e,catch_backtrace())
+    		return
+    	end
+
+    	old_codes = Dict(
+    		id => c.code
+    		for (id,c) in notebook.cells_dict
+    	)
+    	new_codes = Dict(
+    		id => c.code
+    		for (id,c) in just_loaded.cells_dict
+    	)
+
+    	added = setdiff(keys(new_codes), keys(old_codes))
+    	removed = setdiff(keys(old_codes), keys(new_codes))
+    	changed = let
+    		remained = keys(old_codes) ∩ keys(new_codes)
+    		filter(id -> old_codes[id] != new_codes[id], remained)
+    	end
+
+    	# @show added removed changed
+
+    	for c in added
+    		notebook.cells_dict[c] = just_loaded.cells_dict[c]
+    	end
+    	for c in removed
+    		delete!(notebook.cells_dict, c)
+    	end
+    	for c in changed
+    		notebook.cells_dict[c].code = new_codes[c]
+    	end
+    
+    	notebook.cell_order = just_loaded.cell_order
+    	update_save_run!(session, notebook, Cell[notebook.cells_dict[c] for c in union(added, changed)])
+    end
+
+end

--- a/src/Webhook.jl
+++ b/src/Webhook.jl
@@ -85,11 +85,14 @@ module Webhook
                     end
                 end
                 # Create index!
+                running_sessions = filter(notebook_sessions) do sesh
+                    sesh isa RunningNotebookSession
+                end
+                running_paths = map(s -> s.path, running_sessions)
                 if settings.SliderServer.serve_static_export_folder && settings.Export.create_index
-
                     write(joinpath(settings.Export.output_dir, "index.html"), default_index((
                         without_pluto_file_extension(path) => without_pluto_file_extension(path) * ".html"
-                        for path in to_start ∪ to_renew
+                        for path in running_paths
                     )))
                     @info "Wrote index to" settings.Export.output_dir
                 end

--- a/src/Webhook.jl
+++ b/src/Webhook.jl
@@ -8,6 +8,7 @@ module Webhook
     @from "Export.jl" import Export: default_index
     import Pluto: without_pluto_file_extension
     using HTTP
+    using SHA
 
     # This function wraps our functions with PlutoSliderServer context. run_server & start_dir are set by the webhook options.
     function register_webhook!(router, notebook_sessions, server_session, settings, static_dir)

--- a/src/Webhook.jl
+++ b/src/Webhook.jl
@@ -1,0 +1,126 @@
+module Webhook
+    export register_webhook!
+
+    using FromFile
+    @from "./Actions.jl" using Actions
+    using HTTP
+
+    # This function wraps our functions with PlutoSliderServer context. run_server & start_dir are set by the webhook options.
+    function register_webhook!(router, notebook_sessions, server_session, settings, static_dir)
+
+
+        function reload_filesystem(request::HTTP.Request)
+            # Need to save configuration
+            if get(ENV, "GITHUB_SECRET", "") !== ""
+                security_test = validate_github_headers(request, ENV["GITHUB_SECRET"])
+                if !security_test
+                    return HTTP.Response(501, "Not authorized!")
+                end
+            end
+
+            params = HTTP.queryparams(HTTP.URI(request.target))
+            github_url = get(get(JSON.parse(String(request.body)), "repository", Dict()), "html_url", nothing)
+            folder = !isnothing(github_url) ? split(github_url, "/")[end] : "spam"
+            exclude_hases = get(params, "exclude", [])
+            @async try
+                if length(folder) > 0 
+                    toclone = github_url
+                    this_folder = pwd()
+                    @info this_folder
+                    run(`rm -rf "$folder"`)
+                    # Clone without history
+                    # Fetch/Pull if you have latest
+                    # Also have some cleanup around!
+                    run(`git clone --depth 1 "$toclone"`)
+                else 
+                    return HTTP.Response(501, "Can't pull")
+                end
+                start_dir = "$this_folder/$folder"
+
+                @info "New Settings" Text(settings)
+
+                paths = [path for path in find_notebook_files_recursive(start_dir) if !isnothing(path)]
+                new_hashes = map(path_hash, paths)
+
+                running_hashes = map(notebook_sessions) do sesh
+                    sesh isa RunningNotebookSession ? sesh.hash : nothing
+                end
+
+                to_delete = [h for h in running_hashes if !(h ∈ new_hashes) && !isnothing(h)]
+                to_start = [h for h in new_hashes if !(h ∈ running_hashes) && !isnothing(h)]
+                to_run = [p for p in paths if (path_hash(p) ∈ to_start)]
+                @info "delete" to_delete
+                @info "start" to_start
+                @info "to run: " to_run
+                for hash in to_delete
+                    remove_from_session!(notebook_sessions, server_session, hash)
+                end
+
+                for hash in to_start
+                    runpath = paths[findfirst(h -> hash === h, new_hashes)]
+                    add_to_session!(notebook_sessions, server_session, path, settings, run_server=true, start_dir)
+                    @info "started" runpath
+                    generate_static_export(path, settings, original_state=nothing, output_dir=".", jl_contents=nothing)
+                end
+                # Create index!
+                if settings.SliderServer.serve_static_export_folder && settings.Export.create_index
+                    output_dir = something(ENV["current_root"], settings.Export.output_dir, "$start_dir")
+                    write(joinpath(output_dir, "index.html"), default_index((
+                        without_pluto_file_extension(path) => without_pluto_file_extension(path) * ".html"
+                        for path in to_run
+                    )))
+                    @info "Wrote index to" output_dir
+                end
+                @info "run successully!"
+            catch e
+                @warn "Fail in reloading " e
+                showerror(stderr, e, stacktrace(catch_backtrace()))
+                rethrow(e)
+             HTTP.Response(503, "Failed to reload")
+             finally
+            end
+            sleep(max(rand(), 0.1)) # That's both trigger async AND protection against timing attacks :O
+            return HTTP.Response(200, "Webhook accepted, async job started!")
+
+        end
+        # Register Webhook
+        HTTP.@register(router, "POST", "/github_webhook/", reload_filesystem)
+
+        if static_dir === nothing
+            function serve_pluto_asset(request::HTTP.Request)
+                uri = HTTP.URI(request.target)
+                
+                filepath = Pluto.project_relative_path("frontend", relpath(HTTP.unescapeuri(uri.path), "/pluto_asset/"))
+                Pluto.asset_response(filepath)
+            end
+            HTTP.@register(router, "GET", "/pluto_asset/*", serve_pluto_asset)
+            function serve_asset(request::HTTP.Request)
+                uri = HTTP.URI(request.target)
+                
+                filepath = joinpath(static_dir, relpath(HTTP.unescapeuri(uri.path), "/"))
+                Pluto.asset_response(filepath)
+            end
+            HTTP.@register(router, "GET", "/*", serve_asset)
+        end
+    end
+
+
+
+
+    function validate_github_headers(request, secret=ENV["GITHUB_SECRET"])
+        i = findfirst(a -> lowercase(a.first) == lowercase("X-Hub-Signature-256"), request.headers)
+        if (isnothing(i))
+            @warn "Can't validate: header not found"
+            return false
+        end
+        secure_header = request.headers[i].second
+        digest = "sha256=" * bytes2hex(hmac_sha256(collect(codeunits(secret)), request.body))
+        security_test = digest == secure_header
+        sleep(max(0.1, rand()/2))
+        if !security_test
+            return HTTP.Response(501, "Not authorized!")
+        end
+        return security_test
+    end
+
+end


### PR DESCRIPTION
After we refactor the Actions, last piece to generalize is the parts that run the server.

This time, we copy-paste code without removing the old one.

# Features:
- Run notebooks in a repository, respecting the settings
- Update Pluto and PlutoSliderServer when files change and reexport (according to settigns)
- listen for POST at `/github_webhook` endpoint  that triggers git pull (which then triggers re-runs on changed files)

# TODOs
- [ ] Restart on settings change (currently we check but don't do anything: This is different based on context; may be `run(shutdown)` in docker but `run(systemctl service PlutoSliderServer.service restart)` in bare metal machine)
- [ ] Add dockerfile files
- [ ] recreate index every time something gets updated (may happen already)

# Implementation details

`run_server` does the HTTP things and initializes the `notebook_sessions` and `server_session` structs. Then it calls a `on_ready` function.

The `runrepository` function spins of the server and then uses `run_folder` to add files found in a folder into the session.

The `add_to_session` uses FileWatcher to run `renew_session` if the file changes. 

`renew_session` checks for updated file contents (because it may be triggered by `touch file` and calls `update_from_file` in the pluto session. When that returns, session is updated with new hash, state and we're good to go.
