### PR TITLE
bake notebook files by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoSliderServer"
 uuid = "2fc8631c-6f24-4c5b-bca7-cbb509c42db4"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -22,7 +22,7 @@ Configurations = "0.15"
 FromFile = "0.1"
 GitHubActions = "0.1"
 HTTP = "^0.9.3"
-Pluto = "^0.14.3, 0.15"
+Pluto = "^0.14.7, 0.15"
 julia = "1.5"
 
 [extras]

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -90,7 +90,7 @@ module Actions
 
         notebookfile_js = if (settings.Export.offer_binder || settings.Export.slider_server_url !== nothing)
             if settings.Export.baked_state
-                "\"data:;base64,$(base64encode(jl_contents))\""
+                "\"data:text/julia;charset=utf-8;base64,$(base64encode(jl_contents))\""
             else
                 repr(basename(export_jl_path))
             end
@@ -103,7 +103,7 @@ module Actions
             "undefined"
         end
         binder_url_js = if settings.Export.offer_binder
-            repr(something(settings.Export.binder_url, "https://mybinder.org/v2/gh/fonsp/pluto-on-binder/v$(string(Pluto.PLUTO_VERSION))"))
+            repr(something(settings.Export.binder_url, Pluto.default_binder_url))
             # not string(pluto_version) because it has to be an `x.y.z` version number, not a commit hash
         else
             "undefined"

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -89,7 +89,11 @@ module Actions
 
 
         notebookfile_js = if (settings.Export.offer_binder || settings.Export.slider_server_url !== nothing)
-            repr(basename(export_jl_path))
+            if settings.Export.baked_state
+                "\"data:;base64,$(base64encode(jl_contents))\""
+            else
+                repr(basename(export_jl_path))
+            end
         else
             "undefined"
         end
@@ -126,7 +130,7 @@ module Actions
         )
         write(export_html_path, html_contents)
 
-        if (settings.Export.offer_binder || settings.Export.slider_server_url !== nothing)
+        if (settings.Export.offer_binder || settings.Export.slider_server_url !== nothing) && !settings.Export.baked_state
             write(export_jl_path, jl_contents)
         end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -45,6 +45,7 @@ module Types
         ignore_cache::Vector=String[]
         pluto_cdn_root::Union{Nothing,String}=nothing
         baked_state::Bool=true
+        baked_notebookfile::Bool=true
         offer_binder::Bool=true
         disable_ui::Bool=true
         cache_dir::Union{Nothing,String}=nothing

--- a/test/static export.jl
+++ b/test/static export.jl
@@ -61,7 +61,7 @@ end
 end
 
 
-@testset "Separate state files" begin
+@testset "Separate state & notebook files" begin
     test_dir = make_test_dir()
     @show test_dir
     cd(test_dir)
@@ -75,6 +75,7 @@ end
     config_contents = """
     [Export]
     baked_state = false
+    baked_notebookfile = false
     binder_url = "pannenkoek"
     """
 


### PR DESCRIPTION
TODO:
- [x] Wait for the next Pluto release, to make sure that the frontend can handle base64-encoded notebook URLs
- [x] Limit compat to that release