### PR TITLE
Use base64url instead of base64 to avoid escaping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoSliderServer"
 uuid = "2fc8631c-6f24-4c5b-bca7-cbb509c42db4"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"
@@ -30,7 +30,7 @@ FromFile = "0.1"
 Git = "1"
 GitHubActions = "0.1"
 HTTP = "^0.9.3"
-Pluto = "0.17.3, 0.18"
+Pluto = "0.19"
 TerminalLoggers = "0.1"
 julia = "1.6"
 

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -1,6 +1,5 @@
 import Pluto: Pluto, without_pluto_file_extension, generate_html, @asynclog
 using Base64
-using SHA
 using FromFile
 
 @from "./MoreAnalysis.jl" import bound_variable_connections_graph
@@ -8,10 +7,8 @@ using FromFile
 @from "./Types.jl" import NotebookSession, RunningNotebook, FinishedNotebook
 @from "./Configuration.jl" import PlutoDeploySettings
 @from "./FileHelpers.jl" import find_notebook_files_recursive
-myhash = base64encode ∘ sha256
-function path_hash(path)
-    myhash(read(path))
-end
+@from "./PlutoHash.jl" import plutohash
+
 
 showall(xs) = Text(join(string.(xs), "\n"))
 
@@ -61,7 +58,7 @@ function process(
     @info "###### ◐ $(progress) Launching..." s.path
 
     jl_contents = read(abs_path, String)
-    new_hash = myhash(jl_contents)
+    new_hash = plutohash(jl_contents)
     if new_hash != s.desired_hash
         @warn "Notebook file does not have desired hash. This probably means that the file changed too quickly. Continuing and hoping for the best!" s.path new_hash s.desired_hash
     end

--- a/src/Export.jl
+++ b/src/Export.jl
@@ -1,7 +1,5 @@
 import Pluto: Pluto, ServerSession
 using HTTP
-using Base64
-using SHA
 import Pkg
 
 

--- a/src/HTTPRouter.jl
+++ b/src/HTTPRouter.jl
@@ -9,13 +9,12 @@ import Pluto:
     pluto_file_extensions,
     without_pluto_file_extension
 using HTTP
-using Base64
-using SHA
 using Sockets
 
 @from "./Export.jl" import generate_index_html
 @from "./Types.jl" import NotebookSession, RunningNotebook
 @from "./Configuration.jl" import PlutoDeploySettings, get_configuration
+@from "./PlutoHash.jl" import base64urldecode
 
 ready_for_bonds(::Any) = false
 ready_for_bonds(sesh::NotebookSession{String,String,RunningNotebook}) =
@@ -38,7 +37,7 @@ function make_router(
 
         parts = HTTP.URIs.splitpath(uri.path)
         # parts[1] == "staterequest"
-        notebook_hash = parts[2] |> HTTP.unescapeuri
+        notebook_hash = parts[2]
 
         i = findfirst(notebook_sessions) do sesh
             sesh.desired_hash == notebook_hash
@@ -68,11 +67,11 @@ function make_router(
 
             parts = HTTP.URIs.splitpath(uri.path)
             # parts[1] == "staterequest"
-            # notebook_hash = parts[2] |> HTTP.unescapeuri
+            # notebook_hash = parts[2]
 
             @assert length(parts) == 3
 
-            base64decode(parts[3] |> HTTP.unescapeuri)
+            base64urldecode(parts[3])
         end
         bonds_raw = Pluto.unpack(request_body)
 

--- a/src/PlutoHash.jl
+++ b/src/PlutoHash.jl
@@ -15,6 +15,8 @@ This function implements the *`base64url` algorithm*, which is like regular `bas
 See [the wiki](https://en.wikipedia.org/wiki/Base64#Variants_summary_table) or [the official spec (RFC 4648 §5)](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
 """
 
+
+
 """
 ```julia
 base64urldecode(s::AbstractString)::Vector{UInt8}
@@ -23,6 +25,7 @@ base64urldecode(s::AbstractString)::Vector{UInt8}
 $base64url_docs_info
 """
 function base64urldecode(s::AbstractString)::Vector{UInt8}
+    # This is roughly 0.5 as fast as `base64decode`. See https://gist.github.com/fonsp/d2b84265012942dc40d0082b1fd405ba for benchmark and even slower alternatives. Of course, we could copy-paste the Base64 code and modify it to do base64url, but then Donald Knuth would get angry.
     cs = codeunits(s)
     io = IOBuffer(; sizehint=length(cs) + 2)
     iob64_decode = Base64DecodePipe(io)
@@ -44,6 +47,7 @@ base64urlencode(data)::String
 $base64url_docs_info
 """
 function base64urlencode(data)::String
+    # This is roughly 0.5 as fast as `base64encode`. See comment above.
     String(
         replace(
             base64encode(data) |> without_equals |> codeunits,

--- a/src/PlutoHash.jl
+++ b/src/PlutoHash.jl
@@ -1,0 +1,58 @@
+using Base64
+using SHA
+
+const plus = codeunit("+", 1)
+const minus = codeunit("-", 1)
+const slash = codeunit("/", 1)
+const equals = codeunit("=", 1)
+const underscore = codeunit("_", 1)
+
+without_equals(s) = rstrip(s, '=') # is a lazy SubString! yay
+
+const base64url_docs_info = """
+This function implements the *`base64url` algorithm*, which is like regular `base64` but it produces legal URL/filenames: it uses `-` instead of `+`, `_` instead of `/`, and it does not pad (with `=` originally). 
+
+See [the wiki](https://en.wikipedia.org/wiki/Base64#Variants_summary_table) or [the official spec (RFC 4648 §5)](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
+"""
+
+"""
+```julia
+base64urldecode(s::AbstractString)::Vector{UInt8}
+```
+
+$base64url_docs_info
+"""
+function base64urldecode(s::AbstractString)::Vector{UInt8}
+    cs = codeunits(s)
+    io = IOBuffer(; sizehint=length(cs) + 2)
+    iob64_decode = Base64DecodePipe(io)
+    write(io, replace(codeunits(s), minus => plus, underscore => slash))
+
+    for _ = 1:mod(-length(cs), 4)
+        write(io, equals)
+    end
+    seekstart(io)
+    read(iob64_decode)
+end
+
+
+"""
+```julia
+base64urlencode(data)::String
+```
+
+$base64url_docs_info
+"""
+function base64urlencode(data)::String
+    String(
+        replace(
+            base64encode(data) |> without_equals |> codeunits,
+            plus => minus,
+            slash => underscore,
+        ),
+    )
+end
+
+const plutohash = base64urlencode ∘ sha256
+
+plutohash_contents(path) = plutohash(read(path))

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -17,6 +17,9 @@ using FromFile
 @from "./HTTPRouter.jl" import make_router
 @from "./gitpull.jl" import fetch_pull
 
+@from "./PlutoHash.jl" import plutohash, base64urlencode, base64urldecode
+export plutohash, base64urlencode, base64urldecode
+
 import Pluto
 import Pluto:
     ServerSession,
@@ -26,8 +29,6 @@ import Pluto:
     pluto_file_extensions,
     without_pluto_file_extension
 using HTTP
-using Base64
-using SHA
 using Sockets
 import BetterFileWatching: watch_folder
 using TerminalLoggers: TerminalLogger
@@ -221,7 +222,7 @@ function run_directory(
     server_session = Pluto.ServerSession(; options=settings.Pluto)
 
     notebook_sessions = NotebookSession[]
-    # notebook_sessions = NotebookSession[QueuedNotebookSession(;path, current_hash=myhash(read(joinpath(start_dir, path)))) for path in to_run]
+    # notebook_sessions = NotebookSession[QueuedNotebookSession(;path, current_hash=plutohash(read(joinpath(start_dir, path)))) for path in to_run]
 
     if settings.SliderServer.enabled
         static_dir =

--- a/src/ReloadFolder.jl
+++ b/src/ReloadFolder.jl
@@ -1,5 +1,5 @@
 using FromFile
-@from "./Actions.jl" import path_hash
+@from "./PlutoHash.jl" import plutohash_contents
 @from "./Types.jl" import NotebookSession
 @from "./Configuration.jl" import PlutoDeploySettings, get_configuration
 @from "./FileHelpers.jl" import find_notebook_files_recursive
@@ -14,7 +14,7 @@ function d3join(notebook_sessions, new_paths; start_dir::AbstractString)
 
     new_hashes = map(old_paths) do path
         abs_path = joinpath(start_dir, path)
-        isfile(abs_path) ? path_hash(abs_path) : nothing
+        isfile(abs_path) ? plutohash_contents(abs_path) : nothing
     end
 
     (
@@ -46,7 +46,7 @@ function update_sessions!(notebook_sessions, new_paths; start_dir::AbstractStrin
                 NotebookSession(;
                     path=path,
                     current_hash=nothing,
-                    desired_hash=path_hash(joinpath(start_dir, path)),
+                    desired_hash=plutohash_contents(joinpath(start_dir, path)),
                     run=nothing,
                 ),
             )
@@ -59,7 +59,8 @@ function update_sessions!(notebook_sessions, new_paths; start_dir::AbstractStrin
                 path=path,
                 current_hash=old.current_hash,
                 desired_hash=(
-                    path ∈ removed ? nothing : path_hash(joinpath(start_dir, path))
+                    path ∈ removed ? nothing :
+                    plutohash_contents(joinpath(start_dir, path))
                 ),
                 run=old.run,
             )

--- a/test/filewatching.jl
+++ b/test/filewatching.jl
@@ -160,9 +160,8 @@ end
     @testset "Update an existing file" begin
 
         coolconnectionurl(file_hash) =
-            "http://localhost:$(port)/bondconnections/$(HTTP.URIs.escapeuri(file_hash))/"
-        coolbondsurl(file_hash) =
-            "http://localhost:$(port)/staterequest/$(HTTP.URIs.escapeuri(file_hash))/asdf"
+            "http://localhost:$(port)/bondconnections/$(file_hash)/"
+        coolbondsurl(file_hash) = "http://localhost:$(port)/staterequest/$(file_hash)/asdf"
 
         function coolconnectionkeys()
             response = HTTP.get(coolconnectionurl(coolsesh().current_hash))

--- a/test/plutohash.jl
+++ b/test/plutohash.jl
@@ -1,0 +1,27 @@
+using Test
+import PlutoSliderServer: plutohash, base64urlencode, base64urldecode
+import HTTP
+
+@testset "PlutoHash" begin
+    @test plutohash("Hannes") == "OI48wVWerxEEnz5lIj6CPPRB8NOwwba-LkFYTDp4aUU"
+    @test base64urlencode(UInt8[0, 0, 63, 0, 0, 62, 42]) == "AAA_AAA-Kg"
+
+    dir = mktempdir()
+    for _ = 1:50
+        data = rand(UInt8, rand(60:80))
+        e = base64urlencode(data)
+        @test base64urldecode(e) == data
+
+        # URI escaping/unescaping should have no effect
+        @test HTTP.unescapeuri(e) == e
+        @test HTTP.escapeuri(e) == e
+
+        # it should be a legal filename
+        p = joinpath(dir, e)
+        write(p, "123")
+        @test read(p, String) == "123"
+        isfile(p)
+        rm(p)
+        @assert !isfile(p)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ if just_run_test_server
     include("./runtestserver.jl")
 else
     ENV["HIDE_PLUTO_EXACT_VERSION_WARNING"] = "true"
+    include("./plutohash.jl")
     include("./configuration.jl")
     include("./static export.jl")
     include("./staterequest.jl")

--- a/test/staterequest.jl
+++ b/test/staterequest.jl
@@ -4,7 +4,6 @@ import PlutoSliderServer.HTTP
 
 using Test
 using UUIDs
-using Base64
 
 @testset "HTTP requests" begin
     test_dir = tempname(cleanup=false)
@@ -53,9 +52,7 @@ using Base64
     @testset "Bond connections - $(name)" for (i, name) in enumerate(notebook_paths)
         s = notebook_sessions[i]
 
-        response = HTTP.get(
-            "http://localhost:$(port)/bondconnections/$(HTTP.URIs.escapeuri(s.current_hash))/",
-        )
+        response = HTTP.get("http://localhost:$(port)/bondconnections/$(s.current_hash)/")
 
         result = Pluto.unpack(response.body)
 
@@ -78,16 +75,19 @@ using Base64
             sum_cell_id = "26025270-9b5e-4841-b295-0c47437bc7db"
 
             response = if method == "GET"
-                arg = Pluto.pack(bonds) |> base64encode |> HTTP.URIs.escapeuri
+                arg = Pluto.pack(bonds) |> PlutoSliderServer.base64urlencode
+
+                # escaping should have no effect
+                @test HTTP.URIs.escapeuri(arg) == arg
 
                 HTTP.request(
                     method,
-                    "http://localhost:$(port)/staterequest/$(HTTP.URIs.escapeuri(s.current_hash))/$(arg)",
+                    "http://localhost:$(port)/staterequest/$(s.current_hash)/$(arg)",
                 )
             else
                 HTTP.request(
                     method,
-                    "http://localhost:$(port)/staterequest/$(HTTP.URIs.escapeuri(s.current_hash))/",
+                    "http://localhost:$(port)/staterequest/$(s.current_hash)/",
                     [],
                     Pluto.pack(bonds),
                 )


### PR DESCRIPTION
PlutoSliderServer uses a lot of base64, for example, in a staterequest:

```
GET /staterequest/$notebook_hash/$bonds_data
```

We currently use the following as the *Pluto hash*: 
- sha1
- then Base64 encoding
- then URI escaping (e.g. `Hello world` => `Hello%20world`)

And for the bonds data, the same, but without hashing.

The hope was that by URI escaping, we would get legal URLs for base64 data, and additionally, in #29 , legal file names for precomputed states.

But! It turns out that some proxies and some file servers perform URI unescaping before it reaches this package. List of problems:
- https://github.com/JuliaPluto/PlutoSliderServer.jl/issues/42
- https://github.com/JuliaPluto/PlutoSliderServer.jl/issues/45
- https://github.com/JuliaPluto/PlutoSliderServer.jl/issues/46
- More discussion in https://github.com/JuliaPluto/PlutoSliderServer.jl/pull/50#issuecomment-1011650158

# Solution

This PR uses the `base64url` algorithm instead of `base64`:

> This function implements the *`base64url` algorithm*, which is like regular `base64` but it produces legal URL/filenames: it uses `-` instead of `+`, `_` instead of `/`, and it does not pad (with `=` originally). 
> 
> See [the wiki](https://en.wikipedia.org/wiki/Base64#Variants_summary_table) or [the official spec (RFC 4648 §5)](https://datatracker.ietf.org/doc/html/rfc4648#section-5).

# TODO

TODO:
- [ ] Merge matching changes in Pluto: https://github.com/fonsp/Pluto.jl/pull/1969
- [ ] Register a breaking Pluto release and update the compat of PlutoSliderServer
- [x] Test combination with #29 , done in this branch: https://github.com/JuliaPluto/PlutoSliderServer.jl/tree/static-export-1-base64url
- [x] Test combination with Pluto changes