### PR TITLE
Fix possibly empty first request, leaving `missing` as values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoSliderServer"
 uuid = "2fc8631c-6f24-4c5b-bca7-cbb509c42db4"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -28,7 +28,7 @@ FromFile = "0.1"
 Git = "1"
 GitHubActions = "0.1"
 HTTP = "^0.9.3"
-Pluto = "0.15, 0.16, 0.17, 0.18"
+Pluto = "0.17.3, 0.18"
 TerminalLoggers = "0.1"
 julia = "1.6"
 

--- a/src/HTTPRouter.jl
+++ b/src/HTTPRouter.jl
@@ -112,6 +112,7 @@ function make_router(
                         session=server_session,
                         notebook=notebook,
                         bound_sym_names=names,
+                        is_first_values=[false for _n in names], # because requests should be stateless. We might want to do something special for the (actual) initial request (containing every initial bond value) in the future.
                         run_async=false,
                     )::Pluto.TopologicalOrder
 


### PR DESCRIPTION
In https://github.com/fonsp/Pluto.jl/pull/1736 I made a bad choice with the initial value: it was `false` before, but I set it to `true` in the PR. This is fixed in https://github.com/fonsp/Pluto.jl/commit/8014caece313c503915224f5e4f50525712b05fa, but this PR also provides a fix on the PSS side.

This bug can cause problems with the initial request, and leave values on "missing" when people visit a notebook.