### PR TITLE
HTTP Router: Fix asset serving

### DIFF
--- a/src/HTTPRouter.jl
+++ b/src/HTTPRouter.jl
@@ -257,7 +257,7 @@ function make_router(
             filepath = joinpath(static_dir, relpath(HTTP.unescapeuri(uri.path), "/"))
             Pluto.asset_response(filepath)
         end
-        HTTP.register!(router, "GET", "/*", serve_asset)
+        HTTP.register!(router, "GET", "/**", serve_asset)
     end
 
     router


### PR DESCRIPTION
Double wildcard is needed [since HTTP.jl 1.0](https://juliaweb.github.io/HTTP.jl/stable/reference/#HTTP.Handlers.register!).

Fixes #88.