### PR TITLE
Option to use Pluto's Featured GUI as index html

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ GitHubActions = "0.1"
 Glob = "1"
 HTTP = "^1.0.2"
 JSON = "0.21"
-Pluto = "0.19.17"
+Pluto = "0.19.18"
 TerminalLoggers = "0.1"
 julia = "1.6"
 

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -249,7 +249,7 @@ function generate_static_export(
     )
     header_html = Pluto.frontmatter_html(frontmatter)
 
-    html_contents = generate_html(;
+    html_contents = Pluto.generate_html(;
         pluto_cdn_root=settings.Export.pluto_cdn_root,
         version=pluto_version,
         notebookfile_js,

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -46,6 +46,8 @@ end
     cache_dir::Union{Nothing,String} = nothing
     "Automatically generate an `index.html` file, listing all the exported notebooks (only if no `index.jl` or `index.html` file exists already)."
     create_index::Bool = true
+    "Use the Pluto Featured GUI to display the notebooks on the auto-generated index page, using frontmatter for title, description, image, and more. The default is currently `false`, but it might change in the future. Set to `true` or `false` explicitly to fix a value."
+    create_pluto_featured_index::Union{Nothing,Bool} = nothing
     """ADVANCED: URL of the binder repository to load when you click the "Run on binder" button in the top right, this will be set automatically if you leave it at the default value. This setting is quite advanced, and only makes sense if you have a fork of `https://github.com/fonsp/pluto-on-binder/` (because you want to control the binder launch, or because you are using your own fork of Pluto). If so, the setting should be of the form `"https://mybinder.org/v2/gh/fonsp/pluto-on-binder/v0.17.2"`, where `fonsp/pluto-on-binder` is the name of your repository, and `v0.17.2` is a tag or commit hash."""
     binder_url::Union{Nothing,String} = nothing
     pluto_cdn_root::Union{Nothing,String} = nothing

--- a/src/HTTPRouter.jl
+++ b/src/HTTPRouter.jl
@@ -13,7 +13,7 @@ using Sockets
 import JSON
 
 @from "./IndexJSON.jl" import generate_index_json
-@from "./IndexHTML.jl" import temp_index, generate_index_html
+@from "./IndexHTML.jl" import temp_index, generate_basic_index_html
 @from "./Types.jl" import NotebookSession, RunningNotebook
 @from "./Configuration.jl" import PlutoDeploySettings, get_configuration
 @from "./PlutoHash.jl" import base64urldecode
@@ -152,7 +152,7 @@ function make_router(
                 only_relevant(sesh.run.original_state),
                 only_relevant(new_state),
             )
-            patches_as_dicts::Array{Dict} = Firebasey._convert(Array{Dict},patches)
+            patches_as_dicts::Array{Dict} = Firebasey._convert(Array{Dict}, patches)
 
             HTTP.Response(
                 200,

--- a/src/IndexHTML.jl
+++ b/src/IndexHTML.jl
@@ -6,6 +6,7 @@ import Pluto: Pluto, without_pluto_file_extension
 
 @from "./Configuration.jl" import PlutoDeploySettings
 @from "./Types.jl" import NotebookSession, RunningNotebook
+@from "./Export.jl" import try_get_exact_pluto_version
 
 
 function generate_basic_index_html(paths)
@@ -56,7 +57,10 @@ function generate_index_html(
             featured_sources_js="[{url:`./pluto_export.json`}]",
         )
     else
-        temp_index(sessions)
+        generate_basic_index_html((
+            without_pluto_file_extension(s.path) =>
+                without_pluto_file_extension(s.path) * ".html" for s in sessions
+        ))
     end
 end
 

--- a/src/IndexHTML.jl
+++ b/src/IndexHTML.jl
@@ -52,7 +52,6 @@ function generate_index_html(
         Pluto.generate_index_html(;
             pluto_cdn_root=settings.Export.pluto_cdn_root,
             version=try_get_exact_pluto_version(),
-            featured_static=true,
             featured_direct_html_links=true,
             featured_sources_js="[{url:`./pluto_export.json`}]",
         )

--- a/src/IndexHTML.jl
+++ b/src/IndexHTML.jl
@@ -8,7 +8,7 @@ import Pluto: Pluto, without_pluto_file_extension
 @from "./Types.jl" import NotebookSession, RunningNotebook
 
 
-function generate_index_html(paths)
+function generate_basic_index_html(paths)
     """
     <!DOCTYPE html>
     <html lang="en">
@@ -43,10 +43,27 @@ function generate_index_html(paths)
     """
 end
 
+function generate_index_html(
+    sessions::Vector{NotebookSession};
+    settings::PlutoDeploySettings,
+)
+    if something(settings.Export.create_pluto_featured_index, false)
+        Pluto.generate_index_html(;
+            pluto_cdn_root=settings.Export.pluto_cdn_root,
+            version=try_get_exact_pluto_version(),
+            featured_static=true,
+            featured_direct_html_links=true,
+            featured_sources_js="[{url:`./pluto_export.json`}]",
+        )
+    else
+        temp_index(sessions)
+    end
+end
+
 
 
 function temp_index(notebook_sessions::Vector{NotebookSession})
-    generate_index_html(temp_index_item.(notebook_sessions))
+    generate_basic_index_html(Iterators.map(temp_index_item, notebook_sessions))
 end
 function temp_index_item(s::NotebookSession)
     without_pluto_file_extension(s.path) => nothing

--- a/src/IndexJSON.jl
+++ b/src/IndexJSON.jl
@@ -63,13 +63,17 @@ function json_data(
     )
 end
 
-function generate_index_json(s; settings::PlutoDeploySettings, start_dir::AbstractString)
+function generate_index_json(
+    sessions::Vector{NotebookSession};
+    settings::PlutoDeploySettings,
+    start_dir::AbstractString,
+)
     p = joinpath(start_dir, "pluto_export_configuration.json")
     config_data = if isfile(p)
         JSON.parse(read(p, String))::Dict{String,Any}
     else
         Dict{String,Any}()
     end
-    result = json_data(s; settings, start_dir, config_data)
+    result = json_data(sessions; settings, start_dir, config_data)
     JSON.json(result)
 end

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -4,7 +4,7 @@ using FromFile
 
 @from "./MoreAnalysis.jl" import bound_variable_connections_graph
 @from "./FileHelpers.jl" import find_notebook_files_recursive, list_files_recursive
-@from "./IndexHTML.jl" import temp_index
+@from "./IndexHTML.jl" import generate_index_html
 @from "./IndexJSON.jl" import generate_index_json
 @from "./Actions.jl" import process,
     should_shutdown, should_update, should_launch, will_process
@@ -313,7 +313,10 @@ function run_directory(
                 joinpath(output_dir, f) |> isfile
             end
             if !exists
-                write(joinpath(output_dir, "index.html"), temp_index(sessions))
+                write(
+                    joinpath(output_dir, "index.html"),
+                    generate_index_html(sessions; settings),
+                )
             end
 
             # JSON

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -4,7 +4,7 @@ using FromFile
 
 @from "./MoreAnalysis.jl" import bound_variable_connections_graph
 @from "./FileHelpers.jl" import find_notebook_files_recursive, list_files_recursive
-@from "./IndexHTML.jl" import generate_index_html
+@from "./IndexHTML.jl" import temp_index
 @from "./IndexJSON.jl" import generate_index_json
 @from "./Actions.jl" import process,
     should_shutdown, should_update, should_launch, will_process
@@ -313,13 +313,7 @@ function run_directory(
                 joinpath(output_dir, f) |> isfile
             end
             if !exists
-                write(
-                    joinpath(output_dir, "index.html"),
-                    generate_index_html((
-                        without_pluto_file_extension(s.path) =>
-                            without_pluto_file_extension(s.path) * ".html" for s in sessions
-                    )),
-                )
+                write(joinpath(output_dir, "index.html"), temp_index(sessions))
             end
 
             # JSON


### PR DESCRIPTION
New option `create_pluto_featured_index::Union{Nothing,Bool} = nothing` that lets you:

> "Use the Pluto Featured GUI to display the notebooks on the auto-generated index page, using frontmatter for title, description, image, and more. The default is currently `false`, but it might change in the future. Set to `true` or `false` explicitly to fix a value."

Addresses #63 (though some additional work is needed before making it the default), to be used to show the featured notebooks directly on our WIP website.

# TODO
- [ ] test
- [x] https://github.com/fonsp/Pluto.jl/pull/2412
- [ ] wait for pluto release
- [x] update compat bound