### PR TITLE
Verify valid write of statefile to disk

### DIFF
--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -228,9 +228,7 @@ function generate_static_export(
         "undefined"
     end
     statefile_js = if !settings.Export.baked_state
-        open(export_statefile_path, "w") do io
-            Pluto.pack(io, original_state)
-        end
+        write_statefile(export_statefile_path, original_state)
         repr(basename(export_statefile_path))
     else
         statefile64 = base64encode() do io
@@ -268,6 +266,12 @@ function generate_static_export(
     end
 
     @debug "Written to $(export_html_path)"
+end
+
+function write_statefile(path, state)
+    data = Pluto.pack(state)
+    write(path, data)
+    @assert read(path) == data
 end
 
 tryrm(x) = isfile(x) && rm(x)


### PR DESCRIPTION
I have seen two instances where the statefile written to disk is glitched/corrupt: it is still readable by MsgPack, but the structure is totally wrong.

# Reports

Both reports happened on PlutoSliderServer generating a static HTML site on a GHA runner. Both had `Export_baked_state = false`, i.e. the statefile was a separate `.plutostate` file on disk, not embedded as base64 in the HTML file.

The first report was on 1 Nov 2022:

![telegram-cloud-photo-size-4-5985390626579004155-y](https://user-images.githubusercontent.com/6933510/227261004-286ab438-874b-4506-91bb-b8928c9dc074.jpg)

(This is supposed to be structured like this: https://github.com/fonsp/Pluto.jl/blob/v0.19.22-src/src/webserver/Dynamic.jl#L100 )

Luckily enough I stored the original statefile!

[broken statefile huh.plutostate.zip](https://github.com/JuliaPluto/PlutoSliderServer.jl/files/11052960/broken.statefile.huh.plutostate.zip)

Second report was recently on slack. we don't have the statefile anymore, only a screenshot that @pankgeorg took in the chrome devtools, the notebook file and the GHA logs

![image](https://user-images.githubusercontent.com/6933510/227261585-c640725d-288a-40a6-94e9-f75da5ef63e3.png)

Notebook file: https://github.com/IdePHICS/EPFLDoctoralLecture2023/blob/606db3cf62f8ee34662d0d1ba2c930f4b8a35073/Resources/Week2/rfim.jl (might have been one of the commits before)

Action run: https://github.com/IdePHICS/EPFLDoctoralLecture2023/actions/runs/4468560473/jobs/7849468519 (nothing out of the ordinary)

[logs_71.zip](https://github.com/JuliaPluto/PlutoSliderServer.jl/files/11052994/logs_71.zip)


# Observation

You can see that something went wrong while writing `["cell_results"]["<cell id here>"]`. For the cell where it went wrong (`29612df6-203f-42bc-b53b-86af618d60ec` in the Nov case), only part of that Dict is available, and the rest is spread out over parent structures. You see that keys and values are being swapped, and that children of "cell_results" became top-level KV pairs.

# Possible causes

`notebook_to_js` cannot return a `Dict` like this (that would be such a serious Julia bug that it would have been found before). So something must have gone wrong in one of:
- Pluto.pack` (MsgPack), 
- writing to the file,
- in the GHA system (corrupt disk, mistake during git push, etc). 

I find a mistake during `Pluto.pack` unlikely, because this would also have led to bugs in regular Pluto use (with websockets or the static HTML with baked state). I also trust that https://github.com/JuliaIO/MsgPack.jl is well-implemented, also because the spec of MsgPack is not too complex. Still, some possibilities:
- It might be caused by our MsgPack extensions (https://github.com/fonsp/Pluto.jl/blob/main/src/webserver/MsgPack.jl)
- It might be caused by special structures like AppendonlyMarker (the Nov case has glitches in the array of logs, which is an AppendonlyMarker). 

A mistake in the GHA system is unlikely (lots of people use it), and i only have reports of the `.plutostate` files being corrupted.

So I suspect that something went wrong while writing the file (which is something that I know nothing about). This is *especially* likely because we called `Pluto.pack` directly on the file handler IO:

```julia
open(export_statefile_path, "w") do io
    Pluto.pack(io, original_state)
end
```

I have later learned that this is not a good idea for stability (e.g. https://github.com/fonsp/Pluto.jl/pull/976 because the program can get interrupted halfway during a write), and performance (because every single write(io, ...) call has overhead). 

There might also be a bug in MsgPack where using a file handler as the `io` can lead to incorrect results. This might not have surfaced before if applications and the MsgPack tests mostly use memory buffers as IO.

So in this PR, we switch this to first `Pluto.pack`ing to memory, and then writing that `Vector{UInt8}` to the file:

```julia
write(export_statefile_path, Pluto.pack(original_state))
```

I *suspect* that this already fixed the bug. But to also eliminate a problem where `write` just writes the wrong contents, I added a `read` to verify the contents.