### PR TITLE
Full bundling of precomputed slider states

### DIFF
--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -71,8 +71,7 @@ function process(
         !is_glob_match(path, settings.SliderServer.exclude)
     skip_cache =
         keep_running ||
-        is_glob_match(path, settings.Export.ignore_cache) ||
-        path ∈ settings.Export.ignore_cache
+        is_glob_match(path, settings.Export.ignore_cache)
 
     cached_state = skip_cache ? nothing : try_fromcache(settings.Export.cache_dir, new_hash)
 
@@ -136,6 +135,7 @@ function process(
             output_dir,
         )
         # TODO shutdown
+        # TODO cache
     end
 
     @info "### ✓ $(progress) Ready" s.path new_hash

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -32,6 +32,11 @@ end
     "List of notebook files to skip precomputation. Provide paths relative to `start_dir`."
     exclude::Vector{String} = String[]
     max_filesize_per_group::Integer = 1_000_000
+
+    "Combines multiple bind state precomputations into a single file"
+    bundling_enabled::Bool = false
+    "Maximum filesize of a full bundle including all group bond updates. Since these files are sent in full over the internet, their size must be small"
+    max_full_bundle_size::Integer = 500_000
 end
 
 @extract_docs @option struct ExportSettings

--- a/src/precomputed/index.jl
+++ b/src/precomputed/index.jl
@@ -130,10 +130,14 @@ function generate_precomputed_staterequests(
     connections = run.bond_connections
     current_hash = sesh.current_hash
 
+    should_bundle = settings.Precompute.bundling_enabled
+
     @assert run isa RunningNotebook
 
     mkpath(joinpath(output_dir, "bondconnections"))
+    mkpath(joinpath(output_dir, "bundles"))
     mkpath(joinpath(output_dir, "staterequest", URIs.escapeuri(current_hash)))
+    mkpath(joinpath(output_dir, "staterequest-bundled", URIs.escapeuri(current_hash)))
 
     bondconnections_path =
         joinpath(output_dir, "bondconnections", URIs.escapeuri(current_hash))
@@ -156,8 +160,12 @@ function generate_precomputed_staterequests(
         @warn "Notebook cannot be (fully) precomputed" report
     end
 
+    bundle_index = String[]
     foreach(groups) do group::VariableGroupPossibilities
         if group.judgement.should_precompute_all
+            should_bundle_group = should_bundle && group.judgement.can_fully_bundle
+
+            bundle = Dict{String,Any}()
             for (combination, bonds_dict) in combination_iterator(group)
                 filename = Pluto.pack(bonds_dict) |> base64urlencode
                 if length(filename) > 255
@@ -176,10 +184,32 @@ function generate_precomputed_staterequests(
 
                     write(write_path, Pluto.pack(result))
 
+                    if should_bundle_group
+                        bundle[filename] = result
+                    end
+
                     @debug "Written state request to " write_path values =
                         (; (zip(group.names, combination))...)
                 end
             end
+
+            if should_bundle_group
+                bundle_signature = Pluto.pack(sort(group.names)) |> base64urlencode
+                push!(bundle_index, bundle_signature)
+                bundle_path = joinpath(
+                    output_dir,
+                    "staterequest-bundled",
+                    URIs.escapeuri(current_hash),
+                    bundle_signature,
+                )
+                write(bundle_path, Pluto.pack(bundle))
+
+                @debug "Written bundled states to " bundle_path bundle_signature
+            end
         end
     end
+    write(
+        joinpath(output_dir, "bundles", URIs.escapeuri(current_hash)),
+        Pluto.pack(bundle_index),
+    )
 end


### PR DESCRIPTION
This is a draft PR for a draft PR! Precomputed sliders require many files which are often small and very similar to one another. Bundling solves both these problems in one go:
1. Bundles can be stored in a **single larger file**, which can be served statically in its compressed form to reduce size
2. Notebook clients need only request a bundle once, meaning precomputed values contained within load **instantly** once the bundle has been downloaded

With the following notebook we see a massive 96% compression of the `staterequest` folder (where the notebook updates are stored)

```
BEFORE BUNDLING
17M     60qMnIsupXiarVwdoPP2Vg9cewKaBJfJTlSOgeeEtW0/
AFTER BUNDLING + COMPRESSION
608K    60qMnIsupXiarVwdoPP2Vg9cewKaBJfJTlSOgeeEtW0/
```

![Screenshot from 2023-06-14 14-10-32](https://github.com/JuliaPluto/PlutoSliderServer.jl/assets/22894011/9264cb80-35a5-49f3-88da-2c6d009eade3)

There are inherent limitations to this method, so this PR will not be helpful for _all_ notebooks. For very large slider spaces, bundling the entire space will simply be too large to load in a browser. Future changes may or may not address this issue by implementing _partial bundles_ which only include a certain carefully chosen subset of slider values.