### PR TITLE
Make deploying together with Franklin easier

### DIFF
--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -186,17 +186,16 @@ function generate_static_export(
     start_dir,
 )
     pluto_version = try_get_exact_pluto_version()
+    relative_to_notebooks_dir = without_pluto_file_extension(path)
     export_jl_path = let
-        relative_to_notebooks_dir = path
-        joinpath(output_dir, relative_to_notebooks_dir)
+        joinpath(output_dir, relative_to_notebooks_dir, filename(path))
     end
     export_html_path = let
-        relative_to_notebooks_dir = without_pluto_file_extension(path) * ".html"
-        joinpath(output_dir, relative_to_notebooks_dir)
+        joinpath(output_dir, relative_to_notebooks_dir, "index.html")
     end
     export_statefile_path = let
-        relative_to_notebooks_dir = without_pluto_file_extension(path) * ".plutostate"
-        joinpath(output_dir, relative_to_notebooks_dir)
+        joinpath(output_dir, relative_to_notebooks_dir,
+            without_pluto_file_extension(filename(path)) * ".plutostate"
     end
 
 
@@ -220,7 +219,7 @@ function generate_static_export(
     end
     slider_server_url_js = if slider_server_running_somewhere
         abs_path = joinpath(start_dir, path)
-        url_of_root = relpath(start_dir, dirname(abs_path)) # e.g. "." or "../../.." 
+        url_of_root = relpath(start_dir, dirname(abs_path)) # e.g. "." or "../../.."
         repr(something(settings.Export.slider_server_url, url_of_root))
     else
         "undefined"

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -195,7 +195,7 @@ function generate_static_export(
     end
     export_statefile_path = let
         joinpath(output_dir, relative_to_notebooks_dir,
-            without_pluto_file_extension(filename(path)) * ".plutostate"
+		 without_pluto_file_extension(filename(path)) * ".plutostate")
     end
 
 

--- a/src/Actions.jl
+++ b/src/Actions.jl
@@ -188,14 +188,14 @@ function generate_static_export(
     pluto_version = try_get_exact_pluto_version()
     relative_to_notebooks_dir = without_pluto_file_extension(path)
     export_jl_path = let
-        joinpath(output_dir, relative_to_notebooks_dir, filename(path))
+        joinpath(output_dir, relative_to_notebooks_dir, basename(path))
     end
     export_html_path = let
         joinpath(output_dir, relative_to_notebooks_dir, "index.html")
     end
     export_statefile_path = let
         joinpath(output_dir, relative_to_notebooks_dir,
-		 without_pluto_file_extension(filename(path)) * ".plutostate")
+		 without_pluto_file_extension(basename(path)) * ".plutostate")
     end
 
 


### PR DESCRIPTION
This changes the export folder structure to be `notebook_name/index.html` allowing franklin to just ingest that folder structure.
Probably want this to be configurable. 

https://github.com/vchuravy/vchuravy.github.io/blob/c6e13351c86f5d1717d3c864d7cda92b022d9186/.github/workflows/Deploy.yml#L33

I then use the generated json to generate a talks page https://github.com/vchuravy/vchuravy.github.io/blob/c6e13351c86f5d1717d3c864d7cda92b022d9186/utils.jl#L143

x-ref: https://github.com/tlienart/Franklin.jl/issues/813