### PR TITLE
Server Timing API for debugging

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -19,6 +19,7 @@ import Glob
     "Besides handling slider server request, should we also run a static file server of the export output folder? Set to `false` if you are serving the HTML files in another way, e.g. using GitHub Pages, and, for some reason, you do not want to *also* serve the HTML files using this serve."
     serve_static_export_folder::Bool = true
     simulated_lag::Real = 0
+    server_timing_header::Bool = false
     "Cache-Control header sent on requests in which caching is enabled. Set to `no-store, no-cache` to completely disable caching"
     cache_control::String = "public, max-age=315600000, immutable"
 end


### PR DESCRIPTION
This implements the [Server Timing API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Server_timing) that allows you to debug the server performance.

See bottom right in this screenshot

![image](https://github.com/user-attachments/assets/cb48e911-dc74-4c00-8c2e-76d807c83228)

(i fixed the total after the screenshot)