### PR TITLE
🐑 Launch notebooks in parallel

### DIFF
--- a/src/HTTPRouter.jl
+++ b/src/HTTPRouter.jl
@@ -16,7 +16,7 @@ import PlutoDependencyExplorer
 
 
 @from "./IndexJSON.jl" import generate_index_json
-@from "./IndexHTML.jl" import temp_index, generate_basic_index_html
+@from "./IndexHTML.jl" import temp_index
 @from "./Types.jl" import NotebookSession, RunningNotebook, FinishedNotebook
 @from "./Configuration.jl" import PlutoDeploySettings, get_configuration
 @from "./PlutoHash.jl" import base64urldecode


### PR DESCRIPTION
Fix #36 for both the initial launch (like an export) and for folder watching.

Yay I did it! It was easier than I expected 😅

This adds a new configuration: Export.number_of_parallel_tasks:

```julia
    "Maximum number of notebooks to launch in parallel. Set to 1 to run all notebooks sequentially. Default is currently 1 (for testing), but in a future patch release it will be changed to the number of physical CPU cores. (This setting is also used for `SliderServer.watch_dir`.)"
    number_of_parallel_tasks::Union{Nothing,Integer} = 1
```

I will release this with a little trial period, and then make it multiprocess by default.