### PR TITLE
Use Threads.@spawn in refresh_until_synced_asyncmany

### DIFF
--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -351,7 +351,7 @@ function run_directory(
     function refresh_until_synced_asyncmany(args...)
         n_tasks = @something(settings.Export.number_of_parallel_tasks, roughly_the_number_of_physical_cpu_cores())
         @sync for _ in 1:n_tasks
-            @async refresh_until_synced(args...)
+            Threads.@spawn refresh_until_synced(args...)
         end
     end
 


### PR DESCRIPTION
Closes #146.

The function name signals parallelism intent. `@async` schedules on the current thread, so the loop was concurrent but not parallel; on multi-threaded Julia (default since 1.9 with `--threads=auto`), `Threads.@spawn` is the correct primitive for this `@sync for` fan-out and matches the function's name.

Behavior with a single-threaded runtime is unchanged. The work inside `refresh_until_synced` already takes `withlock(notebook_sessions)` around shared state, so no additional synchronization is required.