### PR TITLE
Update to BetterFileWatching 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "PlutoSliderServer"
 uuid = "2fc8631c-6f24-4c5b-bca7-cbb509c42db4"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "1.8.2"
+version = "1.9.0"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 BetterFileWatching = "c9fd44ac-77b5-486c-9482-9798bd063cc6"
+CancellationTokens = "2e8d271d-f2e2-407b-a864-17eb2156783e"
 Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FromFile = "ff7dd447-1dcb-4ce3-b8ac-22a812192de7"
@@ -30,7 +31,8 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AbstractPlutoDingetjes = "1.1"
 Base64 = "1"
-BetterFileWatching = "^0.1.2"
+BetterFileWatching = "1"
+CancellationTokens = "2"
 Configurations = "0.16, 0.17"
 Distributed = "1"
 FromFile = "0.1"

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -36,6 +36,7 @@ using HTTP
 using Sockets
 import Pkg
 import BetterFileWatching: watch_folder
+import CancellationTokens: CancellationTokenSource, get_token, cancel
 import AbstractPlutoDingetjes: is_inside_pluto
 import TerminalLoggers: TerminalLogger
 import Logging: global_logger, ConsoleLogger
@@ -362,6 +363,7 @@ function run_directory(
 
     should_watch = settings.SliderServer.enabled && settings.SliderServer.watch_dir
 
+    watch_token_source = CancellationTokenSource()
     watch_dir_task = Pluto.@asynclog if should_watch
         @info "Watching directory for changes..."
         debounced = kind_of_debounced() do _
@@ -370,7 +372,13 @@ function run_directory(
             refresh_until_synced_asyncmany(true)
         end
         debounced(nothing) # Trigger once directly, in case there were changes during the initial `refresh_until_synced_asyncmany` call.
-        watch_folder(debounced, start_dir)
+        watch_folder(
+            debounced,
+            start_dir,
+            get_token(watch_token_source);
+            # `.git` was ignored by default in BetterFileWatching 0.1, and `run_git_directory` depends on this: `git pull` should not trigger a refresh unless tracked files changed.
+            ignore=rel -> ".git" in split(rel, "/"),
+        )
     end
 
 
@@ -392,8 +400,8 @@ function run_directory(
             @ignorefailure close(http_server)
             if should_watch
                 @info "Stopping directory watching..."
-                istaskdone(watch_dir_task) ||
-                    @ignorefailure schedule(watch_dir_task, e; error=true)
+                # This makes `watch_folder` clean up and return, which finishes `watch_dir_task`. We don't wait for the task: it might be running a (long) refresh, which we don't want to block the shutdown.
+                @ignorefailure cancel(watch_token_source)
             end
             e isa InterruptException || rethrow(e)
             @info "Server exited ✅"

--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -376,7 +376,6 @@ function run_directory(
             debounced,
             start_dir,
             get_token(watch_token_source);
-            # `.git` was ignored by default in BetterFileWatching 0.1, and `run_git_directory` depends on this: `git pull` should not trigger a refresh unless tracked files changed.
             ignore=rel -> ".git" in split(rel, "/"),
         )
     end
@@ -400,8 +399,9 @@ function run_directory(
             @ignorefailure close(http_server)
             if should_watch
                 @info "Stopping directory watching..."
-                # This makes `watch_folder` clean up and return, which finishes `watch_dir_task`. We don't wait for the task: it might be running a (long) refresh, which we don't want to block the shutdown.
-                @ignorefailure cancel(watch_token_source)
+                cancel(watch_token_source)
+                @info "Waiting for watch task to finish..."
+                wait(watch_dir_task)
             end
             e isa InterruptException || rethrow(e)
             @info "Server exited ✅"


### PR DESCRIPTION
_Generated by AI 🤖_

This updates BetterFileWatching from `^0.1.2` to `1`, following the [v1.0 migration guide](https://github.com/JuliaPluto/BetterFileWatching.jl). BetterFileWatching 1.0 is a complete rewrite that uses native Julia API calls instead of a Deno subprocess :)

## Changes

- **Compat**: `BetterFileWatching = "1"`, and a new direct dependency on `CancellationTokens` (which BetterFileWatching itself also depends on).
- **Stopping the watcher**: instead of `schedule(watch_dir_task, e; error=true)`, we now `cancel` a `CancellationTokenSource` whose token is passed to `watch_folder`. This makes `watch_folder` clean up its OS watcher and return cleanly, and we wait for the watch task to finish before returning.
- **Ignoring `.git`**: v0.1 ignored `.git` directories by default, v1.0 does not. We now pass an explicit `ignore` predicate to keep the old behavior. This matters for `run_git_directory`, where `git pull` runs in the watched folder: activity inside `.git` should not trigger a refresh.

Not needed: event-shape migration (`event.paths` → `paths_tuple(event)`), because our callback never looks at the event contents — it just triggers a debounced rescan.

## Testing

- The `Folder watching` test suite passes locally (31/31) with BetterFileWatching 1.0.0: adding, removing and updating notebooks is detected as before.
- Verified in isolation that the `ignore` predicate drops `.git` events while notebook events still come through, and that `cancel` makes `watch_folder` return cleanly.

Also bumps the package version to 1.9.0.

_Generated by AI 🤖_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

