### PR TITLE
Git polling: use git -C instead of cd(), compare FETCH_HEAD

### DIFF
--- a/src/PlutoSliderServer.jl
+++ b/src/PlutoSliderServer.jl
@@ -469,7 +469,7 @@ function run_git_directory(
         try
             fetch_pull(start_dir)
         catch e
-            @warn "git: Error in poll_pull_loop" exception = (e, catch_backtrace())
+            @warn "git: Error in pull loop" exception = (e, catch_backtrace())
         end
     end
 

--- a/src/gitpull.jl
+++ b/src/gitpull.jl
@@ -12,26 +12,22 @@ end
 function fetch(dir=".")::Bool
     branch_name = current_branch_name(dir)
 
-    cd(dir) do
-        run(`$(git()) fetch origin $(branch_name) --quiet`)
+    run(`$(git()) -C $(dir) fetch origin $(branch_name) --quiet`)
 
-        local_hash = read(`$(git()) rev-parse HEAD`, String)
-        remote_hash = read(`$(git()) rev-parse \@\{u\}`, String)
+    local_hash = read(`$(git()) -C $(dir) rev-parse HEAD`, String)
+    remote_hash = read(`$(git()) -C $(dir) rev-parse FETCH_HEAD`, String)
 
-        return local_hash == remote_hash
-    end
+    local_hash == remote_hash
 end
 
 
 function pullhard(dir=".")
     branch_name = current_branch_name(dir)
 
-    cd(dir) do
-        run(`$(git()) reset --hard origin/$(branch_name)`)
-    end
+    run(`$(git()) -C $(dir) reset --hard origin/$(branch_name)`)
 end
 
-function fetch_pull(dir=","; pull_sleep=1)
+function fetch_pull(dir="."; pull_sleep=1)
     in_sync = fetch(dir)
 
     if !in_sync
@@ -40,17 +36,6 @@ function fetch_pull(dir=","; pull_sleep=1)
     end
 end
 
-
-function poll_pull_loop(dir="."; interval=5)
-    while true
-        try
-            fetch_pull(dir)
-        catch e
-            @error "Error in poll_pull_loop" exception=(e, catch_backtrace())
-        end
-        sleep(interval)
-    end
-end
 
 function get_git_hash(path::String)
 	repo = LibGit2.GitRepo(path)


### PR DESCRIPTION
_Generated by AI 🤖_

Small cleanup of the git polling system, keeping the polling design as-is.

## Changes

- **No more `cd()`**: `fetch()` and `pullhard()` used `cd(dir) do ... end`, which changes the working directory of the whole process. Since the pull loop runs as an async task next to the HTTP server and notebook sessions, another task doing relative-path IO in that window would see the wrong directory. They now pass the directory to git with `-C` instead — same behavior, no shared state.
- **`FETCH_HEAD` instead of `@{u}`**: `git rev-parse @{u}` requires a configured upstream and fails on a detached HEAD. Since we just fetched, comparing `HEAD` to `FETCH_HEAD` gives the same answer with fewer preconditions.
- **Typo fix**: `fetch_pull`'s default dir was `","` instead of `"."` (harmless — all callers pass a dir — but still).
- **Removed dead code**: `poll_pull_loop` was unused; the actual loop lives inline in `run_git_directory`. Also fixed the log message there that still referred to it.

## Testing

Verified manually with a bare "remote" repo and a clone that was one commit behind: `fetch` reports out-of-sync, `fetch_pull` hard-resets to the remote commit, a second `fetch` reports in-sync, and `pwd()` stays untouched throughout. Also verified that `fetch` now works on a detached HEAD, where the old `@{u}` version threw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)